### PR TITLE
Delete non-existing dice db entries (issue#8)

### DIFF
--- a/app/src/main/java/org/opensuse/dice/yourstorydice/MainActivity.java
+++ b/app/src/main/java/org/opensuse/dice/yourstorydice/MainActivity.java
@@ -158,7 +158,7 @@ public class MainActivity extends AppCompatActivity
 
     private void setDiceImageView(int position, ImageView imageView, long[] diceImages) {
         if (diceImages[position] < customDiceCount) {
-            SQLiteDatabase readableDb = mDbHelper.getReadableDatabase();
+            SQLiteDatabase readableDb = mDbHelper.getWritableDatabase();
             Cursor cursor = readableDb.rawQuery(
                     "SELECT * FROM " + FeedDiceTable.FeedEntry.TABLE_NAME +
                             " LIMIT 1 OFFSET " + String.valueOf(diceImages[position])
@@ -170,8 +170,19 @@ public class MainActivity extends AppCompatActivity
 
             File path = NewDieActivity.getStorageDir();
             File file = new File(path, fileName);
-            Drawable drawable = Drawable.createFromPath(file.getPath());
-            imageView.setImageDrawable(drawable);
+            if (file.exists()) {
+                Drawable drawable = Drawable.createFromPath(file.getPath());
+                imageView.setImageDrawable(drawable);
+            } else {
+                SQLiteDatabase writableDb = mDbHelper.getWritableDatabase();
+                String tableName = FeedDiceTable.FeedEntry.TABLE_NAME;
+                String tableId = cursor.getString(cursor.getColumnIndex(FeedDiceTable.FeedEntry._ID));
+
+                Log.d("DBAccess", "deleting row with id '" + tableId + "' of table '" + tableName + "'");
+                int deletedRows = writableDb.delete(tableName, FeedDiceTable.FeedEntry._ID + "=?",  new String[] { tableId });
+                writableDb.close();
+                Log.d("DBAccess", "deleted '" + deletedRows + "' rows");
+            }
         } else {
             int index = (int) (diceImages[position] - customDiceCount);
             imageView.setImageResource(defaultDice[index]);


### PR DESCRIPTION
Automatically deletes db entries of dice images, when the corresponding
dice png file doesn't exist anymore in the file system.