### PR TITLE
Fix issue #17 - Avoid saving empty images

### DIFF
--- a/app/src/main/java/org/opensuse/dice/yourstorydice/NewDieActivity.java
+++ b/app/src/main/java/org/opensuse/dice/yourstorydice/NewDieActivity.java
@@ -97,7 +97,15 @@ public class NewDieActivity extends AppCompatActivity {
 
             FileOutputStream out = new FileOutputStream(file);
             canvas.setBackground(null);
-            canvas.getDrawingCache().compress(Bitmap.CompressFormat.PNG, 100, out);
+            Bitmap drawnBitmap = canvas.getDrawingCache();
+            Bitmap emptyBitmap = Bitmap.createBitmap(drawnBitmap.getWidth(), drawnBitmap.getHeight(), drawnBitmap.getConfig());
+            if (drawnBitmap.sameAs(emptyBitmap)) {
+                Snackbar.make(findViewById(R.id.canvas), getString(R.string.error_empty_bitmap), Snackbar.LENGTH_LONG).setAction("Action", null).show();
+                return;
+            } else {
+                drawnBitmap.compress(Bitmap.CompressFormat.PNG, 100, out);
+            }
+
             out.flush();
             out.close();
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -15,6 +15,7 @@
     <!-- New Die -->
     <string name="save">Speichern</string>
     <string name="license">Dieses Bild wird unter der CCO 1.0 Lizenz gespeichert.</string>
+    <string name="error_empty_bitmap">Bild konnte nicht gefunden werden. Bitte mal zuerst ein Bild.</string>
     <string name="error_save_permissions">Bitte aktivier die benötigten Berechtigungen.</string>
     <string name="error_save_fails">Dein Bild konnte nicht gespeichert werden. Ist dein externer Speicher eingehangen?</string>
     <string name="successfully_saved">Dein Bild wurde erfolgreich gespeichert in:</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -15,6 +15,7 @@
     <!-- New Die -->
     <string name="save">Guardar</string>
     <string name="license">La imagen estará bajo la licencia CC0 1.0 al guardarla.</string>
+    <string name="error_empty_bitmap">No hay dibujo que guardar. ¡Haz un dibujo!</string>
     <string name="error_save_permissions">No tienes permisos para guardar imágenes, por favor actívalos</string>
     <string name="error_save_fails">No se ha podido guardar tu imagen, por favor comprueba que el almacenamiento externo está disponible</string>
     <string name="successfully_saved">Tu dibujo se ha guardado correctamente en:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <!-- New Die -->
     <string name="save">Save</string>
     <string name="license">This image will be licensed under CC0 1.0 when saving it.</string>
+    <string name="error_empty_bitmap">This image seems to be empty. Please draw a picture first.</string>
     <string name="error_save_permissions">You have no permissions to save the image, please enable them</string>
     <string name="error_save_fails">Your image couldn\'t be saved, please check that your external storage is mounted</string>
     <string name="successfully_saved">Your image was successfully saved in:</string>


### PR DESCRIPTION
Compares images with an empty bitmap of the same size before saving and
shows an error message to the user, if it is empty.