### PR TITLE
Fix screen orientation of new die activity (related to issue#21)

### DIFF
--- a/app/src/main/java/org/opensuse/dice/yourstorydice/NewDieActivity.java
+++ b/app/src/main/java/org/opensuse/dice/yourstorydice/NewDieActivity.java
@@ -2,6 +2,7 @@ package org.opensuse.dice.yourstorydice;
 
 import android.Manifest;
 import android.content.ContentValues;
+import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.database.sqlite.SQLiteDatabase;
@@ -30,6 +31,9 @@ public class NewDieActivity extends AppCompatActivity {
         mDbHelper = new FeedYourStoryDiceDbHelper(this);
 
         super.onCreate(savedInstanceState);
+
+        // Changing screen orientation would empty the canvas.
+        setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         setContentView(R.layout.activity_new_die);
     }
 


### PR DESCRIPTION
Changing screen orientation flushes the cached bitmap. Hence locking
screen orientation for that activity solves the issue for now.
Later on we might handle orientation changes properly, but for now this
should be good enough.